### PR TITLE
feat (notebooks): New notebook to test bechdelai lib

### DIFF
--- a/database/notebooks/Testing Bechdelai librairy.ipynb
+++ b/database/notebooks/Testing Bechdelai librairy.ipynb
@@ -1,0 +1,1020 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e7378664-e597-4d85-a3ca-2e90a918734a",
+   "metadata": {},
+   "source": [
+    "# Testing Data4Good Season 10 - BechdelAI library"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e2d25e1c-a41f-4fe5-b792-5d6e466b9ace",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting bechdelai\n",
+      "  Downloading bechdelai-0.0.1a2-py3-none-any.whl (42 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m42.9/42.9 kB\u001b[0m \u001b[31m934.3 kB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m \u001b[36m0:00:01\u001b[0m\n",
+      "  Downloading bechdelai-0.0.1a0-py3-none-any.whl (42 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m42.3/42.3 kB\u001b[0m \u001b[31m4.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "  Downloading bechdelai-0.0.0a0-py3-none-any.whl (23 kB)\n",
+      "Collecting tqdm<5.0.0,>=4.62.3\n",
+      "  Downloading tqdm-4.67.1-py3-none-any.whl (78 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m78.5/78.5 kB\u001b[0m \u001b[31m2.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "Collecting pandas<2.0.0,>=1.3.4\n",
+      "  Downloading pandas-1.5.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (11.5 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m11.5/11.5 MB\u001b[0m \u001b[31m6.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "Collecting umap-learn<0.6.0,>=0.5.2\n",
+      "  Downloading umap_learn-0.5.7-py3-none-any.whl (88 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m88.8/88.8 kB\u001b[0m \u001b[31m2.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "Collecting ftfy<7.0.0,>=6.1.1\n",
+      "  Downloading ftfy-6.3.1-py3-none-any.whl (44 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m44.8/44.8 kB\u001b[0m \u001b[31m5.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "Collecting numpy<2.0.0,>=1.21.3\n",
+      "  Downloading numpy-1.26.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (14.2 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m14.2/14.2 MB\u001b[0m \u001b[31m3.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "Collecting jupyter<2.0.0,>=1.0.0\n",
+      "  Downloading jupyter-1.1.1-py2.py3-none-any.whl (2.7 kB)\n",
+      "Collecting python-dotenv>=0.19.2\n",
+      "  Downloading python_dotenv-1.0.1-py3-none-any.whl (19 kB)\n",
+      "Collecting plotly<6.0.0,>=5.3.1\n",
+      "  Downloading plotly-5.24.1-py3-none-any.whl (19.1 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m19.1/19.1 MB\u001b[0m \u001b[31m2.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "Collecting tensorflow<3.0.0,>=2.7.0\n",
+      "  Downloading tensorflow-2.18.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (231.7 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m231.7/231.7 MB\u001b[0m \u001b[31m2.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:02\u001b[0m\n",
+      "Collecting torchvision<0.13.0,>=0.12.0\n",
+      "  Downloading torchvision-0.12.0-cp39-cp39-manylinux2014_aarch64.whl (13.7 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m13.7/13.7 MB\u001b[0m \u001b[31m4.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "Collecting opencv-python<5.0.0,>=4.5.4\n",
+      "  Downloading opencv_python-4.11.0.86-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (42.2 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m42.2/42.2 MB\u001b[0m \u001b[31m3.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "Collecting torchaudio<0.12.0,>=0.11.0\n",
+      "  Downloading torchaudio-0.11.0-cp39-cp39-manylinux2014_aarch64.whl (3.3 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.3/3.3 MB\u001b[0m \u001b[31m4.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "Collecting PyMuPDF<2.0.0,>=1.19.6\n",
+      "  Downloading pymupdf-1.25.3.tar.gz (67.3 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m67.3/67.3 MB\u001b[0m \u001b[31m2.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "  Getting requirements to build wheel ... \u001b[?25ldone\n",
+      "\u001b[?25h  done\n",
+      "done\n",
+      "\u001b[?25hCollecting lxml<5.0.0,>=4.8.0\n",
+      "  Downloading lxml-4.9.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl (6.7 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m6.7/6.7 MB\u001b[0m \u001b[31m6.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "Collecting scikit-learn<2.0.0,>=1.0.1\n",
+      "  Downloading scikit_learn-1.6.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (12.7 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m12.7/12.7 MB\u001b[0m \u001b[31m5.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "Collecting retina-face<0.0.13,>=0.0.12\n",
+      "  Downloading retina_face-0.0.12-py3-none-any.whl (15 kB)\n",
+      "Collecting openpyxl<4.0.0,>=3.0.10\n",
+      "  Downloading openpyxl-3.1.5-py2.py3-none-any.whl (250 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m250.9/250.9 kB\u001b[0m \u001b[31m1.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "Collecting transformers<5.0.0,>=4.17.0\n",
+      "  Downloading transformers-4.49.0-py3-none-any.whl (10.0 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m10.0/10.0 MB\u001b[0m \u001b[31m3.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m0:01\u001b[0m\n",
+      "Collecting streamlit<2.0.0,>=1.9.2\n",
+      "  Downloading streamlit-1.42.2-py2.py3-none-any.whl (9.6 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m9.6/9.6 MB\u001b[0m \u001b[31m6.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "Collecting deepface<0.0.69,>=0.0.68\n",
+      "  Downloading deepface-0.0.68-py3-none-any.whl (61 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m61.4/61.4 kB\u001b[0m \u001b[31m6.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "Collecting torch<2.0.0,>=1.11.0\n",
+      "  Downloading torch-1.13.1-cp39-cp39-manylinux2014_aarch64.whl (60.5 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m60.5/60.5 MB\u001b[0m \u001b[31m5.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "Collecting matplotlib<4.0.0,>=3.4.3\n",
+      "  Downloading matplotlib-3.9.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (8.2 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.2/8.2 MB\u001b[0m \u001b[31m6.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "Collecting Pillow>=5.2.0\n",
+      "  Downloading pillow-11.1.0-cp39-cp39-manylinux_2_28_aarch64.whl (4.4 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.4/4.4 MB\u001b[0m \u001b[31m5.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "Collecting keras>=2.2.0\n",
+      "  Downloading keras-3.8.0-py3-none-any.whl (1.3 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.3/1.3 MB\u001b[0m \u001b[31m7.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0mm\n",
+      "Collecting gdown>=3.10.1\n",
+      "  Downloading gdown-5.2.0-py3-none-any.whl (18 kB)\n",
+      "Collecting Flask>=1.1.2\n",
+      "  Downloading flask-3.1.0-py3-none-any.whl (102 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m103.0/103.0 kB\u001b[0m \u001b[31m7.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "Collecting mtcnn>=0.1.0\n",
+      "  Downloading mtcnn-0.1.1-py3-none-any.whl (2.3 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.3/2.3 MB\u001b[0m \u001b[31m6.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: wcwidth in /usr/local/lib/python3.9/site-packages (from ftfy<7.0.0,>=6.1.1->bechdelai) (0.2.13)\n",
+      "Requirement already satisfied: nbconvert in /usr/local/lib/python3.9/site-packages (from jupyter<2.0.0,>=1.0.0->bechdelai) (7.16.6)\n",
+      "Requirement already satisfied: notebook in /usr/local/lib/python3.9/site-packages (from jupyter<2.0.0,>=1.0.0->bechdelai) (7.3.2)\n",
+      "Requirement already satisfied: jupyterlab in /usr/local/lib/python3.9/site-packages (from jupyter<2.0.0,>=1.0.0->bechdelai) (4.3.5)\n",
+      "Collecting jupyter-console\n",
+      "  Downloading jupyter_console-6.6.3-py3-none-any.whl (24 kB)\n",
+      "Requirement already satisfied: ipykernel in /usr/local/lib/python3.9/site-packages (from jupyter<2.0.0,>=1.0.0->bechdelai) (6.29.5)\n",
+      "Collecting ipywidgets\n",
+      "  Downloading ipywidgets-8.1.5-py3-none-any.whl (139 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m139.8/139.8 kB\u001b[0m \u001b[31m6.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "Collecting cycler>=0.10\n",
+      "  Downloading cycler-0.12.1-py3-none-any.whl (8.3 kB)\n",
+      "Collecting importlib-resources>=3.2.0\n",
+      "  Downloading importlib_resources-6.5.2-py3-none-any.whl (37 kB)\n",
+      "Collecting kiwisolver>=1.3.1\n",
+      "  Downloading kiwisolver-1.4.7-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (1.4 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.4/1.4 MB\u001b[0m \u001b[31m3.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "Collecting contourpy>=1.0.1\n",
+      "  Downloading contourpy-1.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (309 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m309.2/309.2 kB\u001b[0m \u001b[31m3.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: python-dateutil>=2.7 in /usr/local/lib/python3.9/site-packages (from matplotlib<4.0.0,>=3.4.3->bechdelai) (2.9.0.post0)\n",
+      "Collecting pyparsing>=2.3.1\n",
+      "  Downloading pyparsing-3.2.1-py3-none-any.whl (107 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m107.7/107.7 kB\u001b[0m \u001b[31m9.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: packaging>=20.0 in /usr/local/lib/python3.9/site-packages (from matplotlib<4.0.0,>=3.4.3->bechdelai) (24.2)\n",
+      "Collecting fonttools>=4.22.0\n",
+      "  Downloading fonttools-4.56.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (4.6 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.6/4.6 MB\u001b[0m \u001b[31m6.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "Collecting et-xmlfile\n",
+      "  Downloading et_xmlfile-2.0.0-py3-none-any.whl (18 kB)\n",
+      "Collecting pytz>=2020.1\n",
+      "  Downloading pytz-2025.1-py2.py3-none-any.whl (507 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m507.9/507.9 kB\u001b[0m \u001b[31m4.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "Collecting tenacity>=6.2.0\n",
+      "  Downloading tenacity-9.0.0-py3-none-any.whl (28 kB)\n",
+      "Collecting joblib>=1.2.0\n",
+      "  Downloading joblib-1.4.2-py3-none-any.whl (301 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m301.8/301.8 kB\u001b[0m \u001b[31m6.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "Collecting threadpoolctl>=3.1.0\n",
+      "  Downloading threadpoolctl-3.5.0-py3-none-any.whl (18 kB)\n",
+      "Collecting scipy>=1.6.0\n",
+      "  Downloading scipy-1.13.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (33.7 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m33.7/33.7 MB\u001b[0m \u001b[31m8.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "Collecting click<9,>=7.0\n",
+      "  Downloading click-8.1.8-py3-none-any.whl (98 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m98.2/98.2 kB\u001b[0m \u001b[31m5.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "Collecting blinker<2,>=1.0.0\n",
+      "  Downloading blinker-1.9.0-py3-none-any.whl (8.5 kB)\n",
+      "Collecting pydeck<1,>=0.8.0b4\n",
+      "  Downloading pydeck-0.9.1-py2.py3-none-any.whl (6.9 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m6.9/6.9 MB\u001b[0m \u001b[31m4.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "Requirement already satisfied: typing-extensions<5,>=4.4.0 in /usr/local/lib/python3.9/site-packages (from streamlit<2.0.0,>=1.9.2->bechdelai) (4.12.2)\n",
+      "Collecting cachetools<6,>=4.0\n",
+      "  Downloading cachetools-5.5.2-py3-none-any.whl (10 kB)\n",
+      "Requirement already satisfied: tornado<7,>=6.0.3 in /usr/local/lib/python3.9/site-packages (from streamlit<2.0.0,>=1.9.2->bechdelai) (6.4.2)\n",
+      "Collecting protobuf<6,>=3.20\n",
+      "  Downloading protobuf-5.29.3-cp38-abi3-manylinux2014_aarch64.whl (319 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m319.6/319.6 kB\u001b[0m \u001b[31m9.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "Collecting pyarrow>=7.0\n",
+      "  Downloading pyarrow-19.0.1-cp39-cp39-manylinux_2_28_aarch64.whl (40.5 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m40.5/40.5 MB\u001b[0m \u001b[31m8.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "Collecting toml<2,>=0.10.1\n",
+      "  Downloading toml-0.10.2-py2.py3-none-any.whl (16 kB)\n",
+      "Requirement already satisfied: requests<3,>=2.27 in /usr/local/lib/python3.9/site-packages (from streamlit<2.0.0,>=1.9.2->bechdelai) (2.32.3)\n",
+      "Collecting altair<6,>=4.0\n",
+      "  Downloading altair-5.5.0-py3-none-any.whl (731 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m731.2/731.2 kB\u001b[0m \u001b[31m6.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "Collecting gitpython!=3.1.19,<4,>=3.0.7\n",
+      "  Downloading GitPython-3.1.44-py3-none-any.whl (207 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m207.6/207.6 kB\u001b[0m \u001b[31m8.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "Collecting watchdog<7,>=2.1.5\n",
+      "  Downloading watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl (79 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m79.1/79.1 kB\u001b[0m \u001b[31m5.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "Collecting rich<14,>=10.14.0\n",
+      "  Downloading rich-13.9.4-py3-none-any.whl (242 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m242.4/242.4 kB\u001b[0m \u001b[31m6.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "Requirement already satisfied: setuptools in /usr/local/lib/python3.9/site-packages (from tensorflow<3.0.0,>=2.7.0->bechdelai) (58.1.0)\n",
+      "Collecting ml-dtypes<0.5.0,>=0.4.0\n",
+      "  Downloading ml_dtypes-0.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (2.2 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.2/2.2 MB\u001b[0m \u001b[31m4.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "Collecting tensorboard<2.19,>=2.18\n",
+      "  Downloading tensorboard-2.18.0-py3-none-any.whl (5.5 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5.5/5.5 MB\u001b[0m \u001b[31m7.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0mm\n",
+      "\u001b[?25hRequirement already satisfied: six>=1.12.0 in /usr/local/lib/python3.9/site-packages (from tensorflow<3.0.0,>=2.7.0->bechdelai) (1.17.0)\n",
+      "Collecting h5py>=3.11.0\n",
+      "  Downloading h5py-3.13.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (4.3 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.3/4.3 MB\u001b[0m \u001b[31m8.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0mm\n",
+      "Collecting opt-einsum>=2.3.2\n",
+      "  Downloading opt_einsum-3.4.0-py3-none-any.whl (71 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m71.9/71.9 kB\u001b[0m \u001b[31m13.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "Collecting wrapt>=1.11.0\n",
+      "  Downloading wrapt-1.17.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (83 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m83.0/83.0 kB\u001b[0m \u001b[31m9.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "Collecting gast!=0.5.0,!=0.5.1,!=0.5.2,>=0.2.1\n",
+      "  Downloading gast-0.6.0-py3-none-any.whl (21 kB)\n",
+      "Collecting termcolor>=1.1.0\n",
+      "  Downloading termcolor-2.5.0-py3-none-any.whl (7.8 kB)\n",
+      "Collecting astunparse>=1.6.0\n",
+      "  Downloading astunparse-1.6.3-py2.py3-none-any.whl (12 kB)\n",
+      "Collecting tensorflow-io-gcs-filesystem>=0.23.1\n",
+      "  Downloading tensorflow_io_gcs_filesystem-0.37.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (4.8 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.8/4.8 MB\u001b[0m \u001b[31m4.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0mm\n",
+      "Collecting grpcio<2.0,>=1.24.3\n",
+      "  Downloading grpcio-1.70.0-cp39-cp39-manylinux_2_17_aarch64.whl (5.7 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5.7/5.7 MB\u001b[0m \u001b[31m5.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "Collecting flatbuffers>=24.3.25\n",
+      "  Downloading flatbuffers-25.2.10-py2.py3-none-any.whl (30 kB)\n",
+      "Collecting absl-py>=1.0.0\n",
+      "  Downloading absl_py-2.1.0-py3-none-any.whl (133 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m133.7/133.7 kB\u001b[0m \u001b[31m3.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m\n",
+      "Collecting google-pasta>=0.1.1\n",
+      "  Downloading google_pasta-0.2.0-py3-none-any.whl (57 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.5/57.5 kB\u001b[0m \u001b[31m2.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "Collecting libclang>=13.0.0\n",
+      "  Using cached libclang-18.1.1-py2.py3-none-manylinux2014_aarch64.whl (23.8 MB)\n",
+      "Collecting tokenizers<0.22,>=0.21\n",
+      "  Downloading tokenizers-0.21.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (2.9 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.9/2.9 MB\u001b[0m \u001b[31m5.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "Collecting huggingface-hub<1.0,>=0.26.0\n",
+      "  Downloading huggingface_hub-0.29.1-py3-none-any.whl (468 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m468.0/468.0 kB\u001b[0m \u001b[31m3.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: pyyaml>=5.1 in /usr/local/lib/python3.9/site-packages (from transformers<5.0.0,>=4.17.0->bechdelai) (6.0.2)\n",
+      "Collecting safetensors>=0.4.1\n",
+      "  Downloading safetensors-0.5.2-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (450 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m450.1/450.1 kB\u001b[0m \u001b[31m8.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "Collecting filelock\n",
+      "  Downloading filelock-3.17.0-py3-none-any.whl (16 kB)\n",
+      "Collecting regex!=2019.12.17\n",
+      "  Downloading regex-2024.11.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (782 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m782.0/782.0 kB\u001b[0m \u001b[31m10.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "Collecting numba>=0.51.2\n",
+      "  Downloading numba-0.60.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl (3.4 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.4/3.4 MB\u001b[0m \u001b[31m3.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "Collecting pynndescent>=0.5\n",
+      "  Downloading pynndescent-0.5.13-py3-none-any.whl (56 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.9/56.9 kB\u001b[0m \u001b[31m18.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "Requirement already satisfied: jsonschema>=3.0 in /usr/local/lib/python3.9/site-packages (from altair<6,>=4.0->streamlit<2.0.0,>=1.9.2->bechdelai) (4.23.0)\n",
+      "Requirement already satisfied: jinja2 in /usr/local/lib/python3.9/site-packages (from altair<6,>=4.0->streamlit<2.0.0,>=1.9.2->bechdelai) (3.1.5)\n",
+      "Collecting narwhals>=1.14.2\n",
+      "  Downloading narwhals-1.28.0-py3-none-any.whl (308 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m308.9/308.9 kB\u001b[0m \u001b[31m6.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: wheel<1.0,>=0.23.0 in /usr/local/lib/python3.9/site-packages (from astunparse>=1.6.0->tensorflow<3.0.0,>=2.7.0->bechdelai) (0.45.1)\n",
+      "Collecting itsdangerous>=2.2\n",
+      "  Downloading itsdangerous-2.2.0-py3-none-any.whl (16 kB)\n",
+      "Requirement already satisfied: importlib-metadata>=3.6 in /usr/local/lib/python3.9/site-packages (from Flask>=1.1.2->deepface<0.0.69,>=0.0.68->bechdelai) (8.6.1)\n",
+      "Collecting Werkzeug>=3.1\n",
+      "  Downloading werkzeug-3.1.3-py3-none-any.whl (224 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m224.5/224.5 kB\u001b[0m \u001b[31m3.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "Requirement already satisfied: beautifulsoup4 in /usr/local/lib/python3.9/site-packages (from gdown>=3.10.1->deepface<0.0.69,>=0.0.68->bechdelai) (4.13.3)\n",
+      "Collecting gitdb<5,>=4.0.1\n",
+      "  Downloading gitdb-4.0.12-py3-none-any.whl (62 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m62.8/62.8 kB\u001b[0m \u001b[31m5.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "Collecting fsspec>=2023.5.0\n",
+      "  Downloading fsspec-2025.2.0-py3-none-any.whl (184 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m184.5/184.5 kB\u001b[0m \u001b[31m4.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: zipp>=3.1.0 in /usr/local/lib/python3.9/site-packages (from importlib-resources>=3.2.0->matplotlib<4.0.0,>=3.4.3->bechdelai) (3.21.0)\n",
+      "Collecting namex\n",
+      "  Downloading namex-0.0.8-py3-none-any.whl (5.8 kB)\n",
+      "Collecting optree\n",
+      "  Downloading optree-0.14.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (358 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m358.1/358.1 kB\u001b[0m \u001b[31m5.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "Collecting llvmlite<0.44,>=0.43.0dev0\n",
+      "  Downloading llvmlite-0.43.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (42.9 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m42.9/42.9 MB\u001b[0m \u001b[31m1.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.9/site-packages (from requests<3,>=2.27->streamlit<2.0.0,>=1.9.2->bechdelai) (3.10)\n",
+      "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.9/site-packages (from requests<3,>=2.27->streamlit<2.0.0,>=1.9.2->bechdelai) (3.4.1)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.9/site-packages (from requests<3,>=2.27->streamlit<2.0.0,>=1.9.2->bechdelai) (2.3.0)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.9/site-packages (from requests<3,>=2.27->streamlit<2.0.0,>=1.9.2->bechdelai) (2025.1.31)\n",
+      "Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /usr/local/lib/python3.9/site-packages (from rich<14,>=10.14.0->streamlit<2.0.0,>=1.9.2->bechdelai) (2.19.1)\n",
+      "Collecting markdown-it-py>=2.2.0\n",
+      "  Downloading markdown_it_py-3.0.0-py3-none-any.whl (87 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m87.5/87.5 kB\u001b[0m \u001b[31m2.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "Collecting tensorboard-data-server<0.8.0,>=0.7.0\n",
+      "  Downloading tensorboard_data_server-0.7.2-py3-none-any.whl (2.4 kB)\n",
+      "Collecting markdown>=2.6.8\n",
+      "  Downloading Markdown-3.7-py3-none-any.whl (106 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m106.3/106.3 kB\u001b[0m \u001b[31m2.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "Requirement already satisfied: nest-asyncio in /usr/local/lib/python3.9/site-packages (from ipykernel->jupyter<2.0.0,>=1.0.0->bechdelai) (1.6.0)\n",
+      "Requirement already satisfied: jupyter-client>=6.1.12 in /usr/local/lib/python3.9/site-packages (from ipykernel->jupyter<2.0.0,>=1.0.0->bechdelai) (8.6.3)\n",
+      "Requirement already satisfied: comm>=0.1.1 in /usr/local/lib/python3.9/site-packages (from ipykernel->jupyter<2.0.0,>=1.0.0->bechdelai) (0.2.2)\n",
+      "Requirement already satisfied: jupyter-core!=5.0.*,>=4.12 in /usr/local/lib/python3.9/site-packages (from ipykernel->jupyter<2.0.0,>=1.0.0->bechdelai) (5.7.2)\n",
+      "Requirement already satisfied: matplotlib-inline>=0.1 in /usr/local/lib/python3.9/site-packages (from ipykernel->jupyter<2.0.0,>=1.0.0->bechdelai) (0.1.7)\n",
+      "Requirement already satisfied: traitlets>=5.4.0 in /usr/local/lib/python3.9/site-packages (from ipykernel->jupyter<2.0.0,>=1.0.0->bechdelai) (5.14.3)\n",
+      "Requirement already satisfied: ipython>=7.23.1 in /usr/local/lib/python3.9/site-packages (from ipykernel->jupyter<2.0.0,>=1.0.0->bechdelai) (8.18.1)\n",
+      "Requirement already satisfied: pyzmq>=24 in /usr/local/lib/python3.9/site-packages (from ipykernel->jupyter<2.0.0,>=1.0.0->bechdelai) (26.2.1)\n",
+      "Requirement already satisfied: debugpy>=1.6.5 in /usr/local/lib/python3.9/site-packages (from ipykernel->jupyter<2.0.0,>=1.0.0->bechdelai) (1.8.12)\n",
+      "Requirement already satisfied: psutil in /usr/local/lib/python3.9/site-packages (from ipykernel->jupyter<2.0.0,>=1.0.0->bechdelai) (7.0.0)\n",
+      "Collecting widgetsnbextension~=4.0.12\n",
+      "  Downloading widgetsnbextension-4.0.13-py3-none-any.whl (2.3 MB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.3/2.3 MB\u001b[0m \u001b[31m2.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "Collecting jupyterlab-widgets~=3.0.12\n",
+      "  Downloading jupyterlab_widgets-3.0.13-py3-none-any.whl (214 kB)\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m214.4/214.4 kB\u001b[0m \u001b[31m1.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "\u001b[?25hRequirement already satisfied: prompt-toolkit>=3.0.30 in /usr/local/lib/python3.9/site-packages (from jupyter-console->jupyter<2.0.0,>=1.0.0->bechdelai) (3.0.50)\n",
+      "Requirement already satisfied: notebook-shim>=0.2 in /usr/local/lib/python3.9/site-packages (from jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (0.2.4)\n",
+      "Requirement already satisfied: async-lru>=1.0.0 in /usr/local/lib/python3.9/site-packages (from jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (2.0.4)\n",
+      "Requirement already satisfied: jupyterlab-server<3,>=2.27.1 in /usr/local/lib/python3.9/site-packages (from jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (2.27.3)\n",
+      "Requirement already satisfied: jupyter-lsp>=2.0.0 in /usr/local/lib/python3.9/site-packages (from jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (2.2.5)\n",
+      "Requirement already satisfied: jupyter-server<3,>=2.4.0 in /usr/local/lib/python3.9/site-packages (from jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (2.15.0)\n",
+      "Requirement already satisfied: tomli>=1.2.2 in /usr/local/lib/python3.9/site-packages (from jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (2.2.1)\n",
+      "Requirement already satisfied: httpx>=0.25.0 in /usr/local/lib/python3.9/site-packages (from jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (0.28.1)\n",
+      "Requirement already satisfied: defusedxml in /usr/local/lib/python3.9/site-packages (from nbconvert->jupyter<2.0.0,>=1.0.0->bechdelai) (0.7.1)\n",
+      "Requirement already satisfied: pandocfilters>=1.4.1 in /usr/local/lib/python3.9/site-packages (from nbconvert->jupyter<2.0.0,>=1.0.0->bechdelai) (1.5.1)\n",
+      "Requirement already satisfied: bleach[css]!=5.0.0 in /usr/local/lib/python3.9/site-packages (from nbconvert->jupyter<2.0.0,>=1.0.0->bechdelai) (6.2.0)\n",
+      "Requirement already satisfied: markupsafe>=2.0 in /usr/local/lib/python3.9/site-packages (from nbconvert->jupyter<2.0.0,>=1.0.0->bechdelai) (3.0.2)\n",
+      "Requirement already satisfied: jupyterlab-pygments in /usr/local/lib/python3.9/site-packages (from nbconvert->jupyter<2.0.0,>=1.0.0->bechdelai) (0.3.0)\n",
+      "Requirement already satisfied: mistune<4,>=2.0.3 in /usr/local/lib/python3.9/site-packages (from nbconvert->jupyter<2.0.0,>=1.0.0->bechdelai) (3.1.2)\n",
+      "Requirement already satisfied: nbclient>=0.5.0 in /usr/local/lib/python3.9/site-packages (from nbconvert->jupyter<2.0.0,>=1.0.0->bechdelai) (0.10.2)\n",
+      "Requirement already satisfied: nbformat>=5.7 in /usr/local/lib/python3.9/site-packages (from nbconvert->jupyter<2.0.0,>=1.0.0->bechdelai) (5.10.4)\n",
+      "Requirement already satisfied: webencodings in /usr/local/lib/python3.9/site-packages (from bleach[css]!=5.0.0->nbconvert->jupyter<2.0.0,>=1.0.0->bechdelai) (0.5.1)\n",
+      "Requirement already satisfied: tinycss2<1.5,>=1.1.0 in /usr/local/lib/python3.9/site-packages (from bleach[css]!=5.0.0->nbconvert->jupyter<2.0.0,>=1.0.0->bechdelai) (1.4.0)\n",
+      "Collecting smmap<6,>=3.0.1\n",
+      "  Downloading smmap-5.0.2-py3-none-any.whl (24 kB)\n",
+      "Requirement already satisfied: anyio in /usr/local/lib/python3.9/site-packages (from httpx>=0.25.0->jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (4.8.0)\n",
+      "Requirement already satisfied: httpcore==1.* in /usr/local/lib/python3.9/site-packages (from httpx>=0.25.0->jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (1.0.7)\n",
+      "Requirement already satisfied: h11<0.15,>=0.13 in /usr/local/lib/python3.9/site-packages (from httpcore==1.*->httpx>=0.25.0->jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (0.14.0)\n",
+      "Requirement already satisfied: exceptiongroup in /usr/local/lib/python3.9/site-packages (from ipython>=7.23.1->ipykernel->jupyter<2.0.0,>=1.0.0->bechdelai) (1.2.2)\n",
+      "Requirement already satisfied: jedi>=0.16 in /usr/local/lib/python3.9/site-packages (from ipython>=7.23.1->ipykernel->jupyter<2.0.0,>=1.0.0->bechdelai) (0.19.2)\n",
+      "Requirement already satisfied: pexpect>4.3 in /usr/local/lib/python3.9/site-packages (from ipython>=7.23.1->ipykernel->jupyter<2.0.0,>=1.0.0->bechdelai) (4.9.0)\n",
+      "Requirement already satisfied: decorator in /usr/local/lib/python3.9/site-packages (from ipython>=7.23.1->ipykernel->jupyter<2.0.0,>=1.0.0->bechdelai) (5.2.1)\n",
+      "Requirement already satisfied: stack-data in /usr/local/lib/python3.9/site-packages (from ipython>=7.23.1->ipykernel->jupyter<2.0.0,>=1.0.0->bechdelai) (0.6.3)\n",
+      "Requirement already satisfied: rpds-py>=0.7.1 in /usr/local/lib/python3.9/site-packages (from jsonschema>=3.0->altair<6,>=4.0->streamlit<2.0.0,>=1.9.2->bechdelai) (0.23.1)\n",
+      "Requirement already satisfied: referencing>=0.28.4 in /usr/local/lib/python3.9/site-packages (from jsonschema>=3.0->altair<6,>=4.0->streamlit<2.0.0,>=1.9.2->bechdelai) (0.36.2)\n",
+      "Requirement already satisfied: attrs>=22.2.0 in /usr/local/lib/python3.9/site-packages (from jsonschema>=3.0->altair<6,>=4.0->streamlit<2.0.0,>=1.9.2->bechdelai) (25.1.0)\n",
+      "Requirement already satisfied: jsonschema-specifications>=2023.03.6 in /usr/local/lib/python3.9/site-packages (from jsonschema>=3.0->altair<6,>=4.0->streamlit<2.0.0,>=1.9.2->bechdelai) (2024.10.1)\n",
+      "Requirement already satisfied: platformdirs>=2.5 in /usr/local/lib/python3.9/site-packages (from jupyter-core!=5.0.*,>=4.12->ipykernel->jupyter<2.0.0,>=1.0.0->bechdelai) (4.3.6)\n",
+      "Requirement already satisfied: argon2-cffi>=21.1 in /usr/local/lib/python3.9/site-packages (from jupyter-server<3,>=2.4.0->jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (23.1.0)\n",
+      "Requirement already satisfied: jupyter-events>=0.11.0 in /usr/local/lib/python3.9/site-packages (from jupyter-server<3,>=2.4.0->jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (0.12.0)\n",
+      "Requirement already satisfied: terminado>=0.8.3 in /usr/local/lib/python3.9/site-packages (from jupyter-server<3,>=2.4.0->jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (0.18.1)\n",
+      "Requirement already satisfied: overrides>=5.0 in /usr/local/lib/python3.9/site-packages (from jupyter-server<3,>=2.4.0->jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (7.7.0)\n",
+      "Requirement already satisfied: prometheus-client>=0.9 in /usr/local/lib/python3.9/site-packages (from jupyter-server<3,>=2.4.0->jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (0.21.1)\n",
+      "Requirement already satisfied: send2trash>=1.8.2 in /usr/local/lib/python3.9/site-packages (from jupyter-server<3,>=2.4.0->jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (1.8.3)\n",
+      "Requirement already satisfied: jupyter-server-terminals>=0.4.4 in /usr/local/lib/python3.9/site-packages (from jupyter-server<3,>=2.4.0->jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (0.5.3)\n",
+      "Requirement already satisfied: websocket-client>=1.7 in /usr/local/lib/python3.9/site-packages (from jupyter-server<3,>=2.4.0->jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (1.8.0)\n",
+      "Requirement already satisfied: json5>=0.9.0 in /usr/local/lib/python3.9/site-packages (from jupyterlab-server<3,>=2.27.1->jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (0.10.0)\n",
+      "Requirement already satisfied: babel>=2.10 in /usr/local/lib/python3.9/site-packages (from jupyterlab-server<3,>=2.27.1->jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (2.17.0)\n",
+      "Collecting mdurl~=0.1\n",
+      "  Downloading mdurl-0.1.2-py3-none-any.whl (10.0 kB)\n",
+      "Requirement already satisfied: fastjsonschema>=2.15 in /usr/local/lib/python3.9/site-packages (from nbformat>=5.7->nbconvert->jupyter<2.0.0,>=1.0.0->bechdelai) (2.21.1)\n",
+      "Requirement already satisfied: soupsieve>1.2 in /usr/local/lib/python3.9/site-packages (from beautifulsoup4->gdown>=3.10.1->deepface<0.0.69,>=0.0.68->bechdelai) (2.6)\n",
+      "Collecting PySocks!=1.5.7,>=1.5.6\n",
+      "  Downloading PySocks-1.7.1-py3-none-any.whl (16 kB)\n",
+      "Requirement already satisfied: sniffio>=1.1 in /usr/local/lib/python3.9/site-packages (from anyio->httpx>=0.25.0->jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (1.3.1)\n",
+      "Requirement already satisfied: argon2-cffi-bindings in /usr/local/lib/python3.9/site-packages (from argon2-cffi>=21.1->jupyter-server<3,>=2.4.0->jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (21.2.0)\n",
+      "Requirement already satisfied: parso<0.9.0,>=0.8.4 in /usr/local/lib/python3.9/site-packages (from jedi>=0.16->ipython>=7.23.1->ipykernel->jupyter<2.0.0,>=1.0.0->bechdelai) (0.8.4)\n",
+      "Requirement already satisfied: python-json-logger>=2.0.4 in /usr/local/lib/python3.9/site-packages (from jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (3.2.1)\n",
+      "Requirement already satisfied: rfc3339-validator in /usr/local/lib/python3.9/site-packages (from jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (0.1.4)\n",
+      "Requirement already satisfied: rfc3986-validator>=0.1.1 in /usr/local/lib/python3.9/site-packages (from jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (0.1.1)\n",
+      "Requirement already satisfied: ptyprocess>=0.5 in /usr/local/lib/python3.9/site-packages (from pexpect>4.3->ipython>=7.23.1->ipykernel->jupyter<2.0.0,>=1.0.0->bechdelai) (0.7.0)\n",
+      "Requirement already satisfied: pure-eval in /usr/local/lib/python3.9/site-packages (from stack-data->ipython>=7.23.1->ipykernel->jupyter<2.0.0,>=1.0.0->bechdelai) (0.2.3)\n",
+      "Requirement already satisfied: asttokens>=2.1.0 in /usr/local/lib/python3.9/site-packages (from stack-data->ipython>=7.23.1->ipykernel->jupyter<2.0.0,>=1.0.0->bechdelai) (3.0.0)\n",
+      "Requirement already satisfied: executing>=1.2.0 in /usr/local/lib/python3.9/site-packages (from stack-data->ipython>=7.23.1->ipykernel->jupyter<2.0.0,>=1.0.0->bechdelai) (2.2.0)\n",
+      "Requirement already satisfied: webcolors>=24.6.0 in /usr/local/lib/python3.9/site-packages (from jsonschema>=3.0->altair<6,>=4.0->streamlit<2.0.0,>=1.9.2->bechdelai) (24.11.1)\n",
+      "Requirement already satisfied: fqdn in /usr/local/lib/python3.9/site-packages (from jsonschema>=3.0->altair<6,>=4.0->streamlit<2.0.0,>=1.9.2->bechdelai) (1.5.1)\n",
+      "Requirement already satisfied: uri-template in /usr/local/lib/python3.9/site-packages (from jsonschema>=3.0->altair<6,>=4.0->streamlit<2.0.0,>=1.9.2->bechdelai) (1.3.0)\n",
+      "Requirement already satisfied: jsonpointer>1.13 in /usr/local/lib/python3.9/site-packages (from jsonschema>=3.0->altair<6,>=4.0->streamlit<2.0.0,>=1.9.2->bechdelai) (3.0.0)\n",
+      "Requirement already satisfied: isoduration in /usr/local/lib/python3.9/site-packages (from jsonschema>=3.0->altair<6,>=4.0->streamlit<2.0.0,>=1.9.2->bechdelai) (20.11.0)\n",
+      "Requirement already satisfied: cffi>=1.0.1 in /usr/local/lib/python3.9/site-packages (from argon2-cffi-bindings->argon2-cffi>=21.1->jupyter-server<3,>=2.4.0->jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (1.17.1)\n",
+      "Requirement already satisfied: pycparser in /usr/local/lib/python3.9/site-packages (from cffi>=1.0.1->argon2-cffi-bindings->argon2-cffi>=21.1->jupyter-server<3,>=2.4.0->jupyterlab->jupyter<2.0.0,>=1.0.0->bechdelai) (2.22)\n",
+      "Requirement already satisfied: arrow>=0.15.0 in /usr/local/lib/python3.9/site-packages (from isoduration->jsonschema>=3.0->altair<6,>=4.0->streamlit<2.0.0,>=1.9.2->bechdelai) (1.3.0)\n",
+      "Requirement already satisfied: types-python-dateutil>=2.8.10 in /usr/local/lib/python3.9/site-packages (from arrow>=0.15.0->isoduration->jsonschema>=3.0->altair<6,>=4.0->streamlit<2.0.0,>=1.9.2->bechdelai) (2.9.0.20241206)\n",
+      "Building wheels for collected packages: PyMuPDF\n",
+      "  Building wheel for PyMuPDF (pyproject.toml) ... \u001b[?25ldone\n",
+      "\u001b[?25h  Created wheel for PyMuPDF: filename=pymupdf-1.25.3-cp39-abi3-linux_aarch64.whl size=19366185 sha256=0fd4a7030e81e783136e1694b7adfab5661658f99f21817b5f617b278e5ea41c\n",
+      "  Stored in directory: /root/.cache/pip/wheels/7d/2a/ea/800807935efea8853690c9b8c8df93552129b5074ec852f56b\n",
+      "Successfully built PyMuPDF\n",
+      "Installing collected packages: pytz, namex, libclang, flatbuffers, wrapt, widgetsnbextension, Werkzeug, watchdog, tqdm, torch, toml, threadpoolctl, termcolor, tensorflow-io-gcs-filesystem, tensorboard-data-server, tenacity, smmap, safetensors, regex, python-dotenv, PySocks, pyparsing, PyMuPDF, pyarrow, protobuf, Pillow, optree, opt-einsum, numpy, narwhals, mdurl, lxml, llvmlite, kiwisolver, jupyterlab-widgets, joblib, itsdangerous, importlib-resources, grpcio, google-pasta, gast, ftfy, fsspec, fonttools, filelock, et-xmlfile, cycler, click, cachetools, blinker, astunparse, absl-py, torchvision, torchaudio, scipy, pydeck, plotly, pandas, openpyxl, opencv-python, numba, ml-dtypes, markdown-it-py, markdown, huggingface-hub, h5py, gitdb, Flask, contourpy, tokenizers, tensorboard, scikit-learn, rich, matplotlib, ipywidgets, gitpython, gdown, transformers, pynndescent, keras, jupyter-console, altair, umap-learn, tensorflow, streamlit, mtcnn, retina-face, deepface, jupyter, bechdelai\n",
+      "Successfully installed Flask-3.1.0 Pillow-11.1.0 PyMuPDF-1.25.3 PySocks-1.7.1 Werkzeug-3.1.3 absl-py-2.1.0 altair-5.5.0 astunparse-1.6.3 bechdelai-0.0.0a0 blinker-1.9.0 cachetools-5.5.2 click-8.1.8 contourpy-1.3.0 cycler-0.12.1 deepface-0.0.68 et-xmlfile-2.0.0 filelock-3.17.0 flatbuffers-25.2.10 fonttools-4.56.0 fsspec-2025.2.0 ftfy-6.3.1 gast-0.6.0 gdown-5.2.0 gitdb-4.0.12 gitpython-3.1.44 google-pasta-0.2.0 grpcio-1.70.0 h5py-3.13.0 huggingface-hub-0.29.1 importlib-resources-6.5.2 ipywidgets-8.1.5 itsdangerous-2.2.0 joblib-1.4.2 jupyter-1.1.1 jupyter-console-6.6.3 jupyterlab-widgets-3.0.13 keras-3.8.0 kiwisolver-1.4.7 libclang-18.1.1 llvmlite-0.43.0 lxml-4.9.4 markdown-3.7 markdown-it-py-3.0.0 matplotlib-3.9.4 mdurl-0.1.2 ml-dtypes-0.4.1 mtcnn-0.1.1 namex-0.0.8 narwhals-1.28.0 numba-0.60.0 numpy-1.26.4 opencv-python-4.11.0.86 openpyxl-3.1.5 opt-einsum-3.4.0 optree-0.14.0 pandas-1.5.3 plotly-5.24.1 protobuf-5.29.3 pyarrow-19.0.1 pydeck-0.9.1 pynndescent-0.5.13 pyparsing-3.2.1 python-dotenv-1.0.1 pytz-2025.1 regex-2024.11.6 retina-face-0.0.12 rich-13.9.4 safetensors-0.5.2 scikit-learn-1.6.1 scipy-1.13.1 smmap-5.0.2 streamlit-1.42.2 tenacity-9.0.0 tensorboard-2.18.0 tensorboard-data-server-0.7.2 tensorflow-2.18.0 tensorflow-io-gcs-filesystem-0.37.1 termcolor-2.5.0 threadpoolctl-3.5.0 tokenizers-0.21.0 toml-0.10.2 torch-1.13.1 torchaudio-0.11.0 torchvision-0.12.0 tqdm-4.67.1 transformers-4.49.0 umap-learn-0.5.7 watchdog-6.0.0 widgetsnbextension-4.0.13 wrapt-1.17.2\n",
+      "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv\u001b[0m\u001b[33m\n",
+      "\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.0.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.0.1\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "pip install bechdelai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78cc7832-0a9b-4197-b0d1-3a34dd1bf2a4",
+   "metadata": {},
+   "source": [
+    "## Checking the modules accessible in bechdelai"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "id": "d599aa4a-89ba-4d9c-84f3-615e88a0174d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__', 'data']\n",
+      "['__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__', 'imdb', 'imsdb', 'scrap']\n"
+     ]
+    }
+   ],
+   "source": [
+    "import bechdelai\n",
+    "print(dir(bechdelai))\n",
+    "print(dir(bechdelai.data))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "id": "fbd49468-1d2e-425b-900e-da2d15c1e14a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['BeautifulSoup', 'MAIN_URL', 'RequestException', 'URL_SEARCH', '__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__spec__', '_postprocess_one_cast', 'find_movie_from_kerword', 'get_data_from_url', 'get_movie_casts', 'get_movie_data', 'get_movie_details', 'get_movie_job_details', 'np', 'postprocess_cast_id', 'preprocess_search_result_list', 'scrap_movie_from_suggestions']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(dir(bechdelai.data.imdb))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "id": "327f304d-3636-4781-8c12-82c663c41a75",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['ALL_URL', 'BASE_URL', 'BeautifulSoup', '__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__spec__', 'get_all_scripts', 'get_data_from_url', 'get_script_from_url', 'pd']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(dir(bechdelai.data.imsdb))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 73,
+   "id": "6f7afd1a-164a-4f5c-a660-be992cd9fcee",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['DEFAULT_HEADER', 'NotJSONContentException', 'RequestException', '__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__spec__', 'create_header', 'get_data_from_url', 'get_json_from_url', 'requests']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(dir(bechdelai.data.scrap))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b08b871c-4653-4313-94d7-de3ea93e2e65",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
+   "source": [
+    "## Testing scraping IMSDB - all scenarios"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "351e4327-0f20-496b-a2e1-eec29342d4e2",
+   "metadata": {},
+   "source": [
+    "<span style=\"color: green;\"><b>BechdelAI status on scraping IMSDB: SUCCESS</b></span>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "id": "cad1ee28-79d0-4105-9ae6-a46244e696f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bechdelai.data.imsdb import get_all_scripts, get_script_from_url"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "cddb7014-992f-43c0-86f2-b435faa262f6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>title</th>\n",
+       "      <th>url</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>10 Things I Hate About You</td>\n",
+       "      <td>https://imsdb.com/scripts/10-Things-I-Hate-Abo...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>12</td>\n",
+       "      <td>https://imsdb.com/scripts/12.html</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>12 and Holding</td>\n",
+       "      <td>https://imsdb.com/scripts/12-and-Holding.html</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>12 Monkeys</td>\n",
+       "      <td>https://imsdb.com/scripts/12-Monkeys.html</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>12 Years a Slave</td>\n",
+       "      <td>https://imsdb.com/scripts/12-Years-a-Slave.html</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                        title  \\\n",
+       "0  10 Things I Hate About You   \n",
+       "1                          12   \n",
+       "2              12 and Holding   \n",
+       "3                  12 Monkeys   \n",
+       "4            12 Years a Slave   \n",
+       "\n",
+       "                                                 url  \n",
+       "0  https://imsdb.com/scripts/10-Things-I-Hate-Abo...  \n",
+       "1                  https://imsdb.com/scripts/12.html  \n",
+       "2      https://imsdb.com/scripts/12-and-Holding.html  \n",
+       "3          https://imsdb.com/scripts/12-Monkeys.html  \n",
+       "4    https://imsdb.com/scripts/12-Years-a-Slave.html  "
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "scripts = get_all_scripts()\n",
+    "scripts.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "9d3273ea-7abf-470b-8f18-22eb7d69fb32",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://imsdb.com/scripts/10-Things-I-Hate-About-You.html\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['\\r',\n",
+       " '                               TEN THINGS I HATE ABOUT YOU\\r',\n",
+       " '          \\r',\n",
+       " '                written by Karen McCullah Lutz & Kirsten Smith\\r',\n",
+       " '          \\r',\n",
+       " '              based on \\'Taming of the Shrew\" by William Shakespeare\\r',\n",
+       " '          \\r',\n",
+       " '          Revision November 12, 1997\\r',\n",
+       " '          \\r',\n",
+       " '          \\r',\n",
+       " '          PADUA HIGH SCHOOL - DAY\\r',\n",
+       " '          \\r',\n",
+       " '          Welcome to Padua High School,, your typical urban-suburban \\r',\n",
+       " '          high school in Portland, Oregon.  Smarties, Skids, Preppies, \\r',\n",
+       " '          Granolas. Loners, Lovers, the In and the Out Crowd rub sleep \\r',\n",
+       " '          out of their eyes and head for the main building.\\r',\n",
+       " '          \\r',\n",
+       " '          PADUA HIGH PARKING LOT - DAY\\r',\n",
+       " '          \\r',\n",
+       " '          KAT STRATFORD, eighteen, pretty -- but trying hard not to be \\r']"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "script_url = scripts.at[0, 'url']\n",
+    "print(script_url)\n",
+    "script = get_script_from_url(script_url)\n",
+    "script[:20]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b58ee616-cf8a-4191-9ab4-b87f84ea5a56",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
+   "source": [
+    "## Testing scraping IMDB"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7bdb4cf1-6be0-49ec-bfd3-38a4a94da8ae",
+   "metadata": {},
+   "source": [
+    "<span style=\"color: red;\"><b>BechdelAI status on scraping IMDB: FAILURE</b></span>  \n",
+    "=> Issue could be solved - maybe just a change in html structure on IMDB"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "b55fe940-d140-4914-9471-c235e9b364d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bechdelai.data.imdb import find_movie_from_kerword, get_movie_data, get_movie_details, get_movie_casts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "7e6b97a7-0729-49ea-80b6-aba507310226",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[]\n",
+      "CPU times: user 70.8 ms, sys: 7.58 ms, total: 78.4 ms\n",
+      "Wall time: 939 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "ans = find_movie_from_kerword(q=\"batman\")\n",
+    "print(ans)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "c9701c93-65bd-4eec-adab-9e4119fd8d75",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://www.imdb.com/title/tt1877830/\n"
+     ]
+    },
+    {
+     "ename": "AttributeError",
+     "evalue": "'NoneType' object has no attribute 'find_all'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[46], line 4\u001b[0m\n\u001b[1;32m      2\u001b[0m url \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mhttps://www.imdb.com/title/\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mimdb_id\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m/\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m      3\u001b[0m \u001b[38;5;28mprint\u001b[39m(url)\n\u001b[0;32m----> 4\u001b[0m \u001b[43mget_movie_details\u001b[49m\u001b[43m(\u001b[49m\u001b[43murl\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/usr/local/lib/python3.9/site-packages/bechdelai/data/imdb.py:54\u001b[0m, in \u001b[0;36mget_movie_details\u001b[0;34m(url)\u001b[0m\n\u001b[1;32m     50\u001b[0m soup \u001b[38;5;241m=\u001b[39m BeautifulSoup(ans\u001b[38;5;241m.\u001b[39mtext, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mhtml.parser\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m     52\u001b[0m title \u001b[38;5;241m=\u001b[39m soup\u001b[38;5;241m.\u001b[39mfind(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mh1\u001b[39m\u001b[38;5;124m\"\u001b[39m)\u001b[38;5;241m.\u001b[39mtext\n\u001b[0;32m---> 54\u001b[0m info \u001b[38;5;241m=\u001b[39m \u001b[43msoup\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfind\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mul\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m{\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mdata-testid\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m:\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mhero-title-block__metadata\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m}\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfind_all\u001b[49m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mli\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m     55\u001b[0m date \u001b[38;5;241m=\u001b[39m info[\u001b[38;5;241m0\u001b[39m]\u001b[38;5;241m.\u001b[39mfind(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124ma\u001b[39m\u001b[38;5;124m\"\u001b[39m)\u001b[38;5;241m.\u001b[39mtext\n\u001b[1;32m     56\u001b[0m duration \u001b[38;5;241m=\u001b[39m info[\u001b[38;5;241m2\u001b[39m]\u001b[38;5;241m.\u001b[39mtext\n",
+      "\u001b[0;31mAttributeError\u001b[0m: 'NoneType' object has no attribute 'find_all'"
+     ]
+    }
+   ],
+   "source": [
+    "imdb_id = 'tt1877830'\n",
+    "url = f\"https://www.imdb.com/title/{imdb_id}/\"\n",
+    "print(url)\n",
+    "get_movie_details(url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "4a5c308a-72f3-4125-81d6-e666b06e4317",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "'NoneType' object has no attribute 'find_all'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[49], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mget_movie_casts\u001b[49m\u001b[43m(\u001b[49m\u001b[43murl\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/usr/local/lib/python3.9/site-packages/bechdelai/data/imdb.py:66\u001b[0m, in \u001b[0;36mget_movie_casts\u001b[0;34m(url)\u001b[0m\n\u001b[1;32m     63\u001b[0m ans \u001b[38;5;241m=\u001b[39m get_data_from_url(url)\n\u001b[1;32m     64\u001b[0m soup \u001b[38;5;241m=\u001b[39m BeautifulSoup(ans\u001b[38;5;241m.\u001b[39mtext, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mhtml.parser\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m---> 66\u001b[0m cast_list \u001b[38;5;241m=\u001b[39m \u001b[43msoup\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfind\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mtable\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m{\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mclass\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m:\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mcast_list\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m}\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfind_all\u001b[49m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtr\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m     67\u001b[0m cast \u001b[38;5;241m=\u001b[39m []\n\u001b[1;32m     68\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m elem \u001b[38;5;129;01min\u001b[39;00m cast_list:\n",
+      "\u001b[0;31mAttributeError\u001b[0m: 'NoneType' object has no attribute 'find_all'"
+     ]
+    }
+   ],
+   "source": [
+    "get_movie_casts(url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9eabda4-47d6-45c3-86af-bb8c1b9943ac",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
+   "source": [
+    "## Testing scraping BechdelTest.com"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4096fb32-1d5c-4097-a162-7722ef08232e",
+   "metadata": {},
+   "source": [
+    "<span style=\"color: red;\"><b>BechdelAI status on scraping Bechdeltest.com: FAILURE</b></span>  \n",
+    "=> Module was not integrated. We can use the code because it is very simple"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "abce410e-5a5f-482d-9e65-8b9279cea1d4",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'bechdelai.data.bechdeltestcom'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[53], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21;01mbechdelai\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mdata\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mbechdeltestcom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m get_all_data\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'bechdelai.data.bechdeltestcom'"
+     ]
+    }
+   ],
+   "source": [
+    "from bechdelai.data.bechdeltestcom import get_all_data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8ed788d-3999-48a6-ad3c-cf87445a2554",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
+   "source": [
+    "## Testing scraping Allocine"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5219520f-5db6-413a-b4ab-fd0a7639a6d3",
+   "metadata": {},
+   "source": [
+    "<span style=\"color: red;\"><b>BechdelAI status on scraping Allocine: FAILURE</b></span>  \n",
+    "=> Module was not integrated. We can use the code because it is clean"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "id": "1719ff58-979f-482a-b827-6ded2c0c1584",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'bechdelai.data.allocine'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[57], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# from bechdelai.data.allocine import get_movies\u001b[39;00m\n\u001b[0;32m----> 2\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21;01mbechdelai\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mdata\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mallocine\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m get_tmdb_ids\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'bechdelai.data.allocine'"
+     ]
+    }
+   ],
+   "source": [
+    "# from bechdelai.data.allocine import get_movies\n",
+    "from bechdelai.data.allocine import get_tmdb_ids"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a5ecbc5-9871-4140-9854-6ca1e6501dbe",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
+   "source": [
+    "## Testing scraping OpenSubtitles"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "198b9410-2326-448f-ab40-127696d7f5d1",
+   "metadata": {},
+   "source": [
+    "<span style=\"color: red;\"><b>BechdelAI status on scraping OpenSubtitles: FAILURE</b></span>  \n",
+    "=> Module was not integrated. We can use the code because it is clean"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "id": "eb567346-5aad-438b-87b2-011317cd6231",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'bechdelai.data.opensubtitles'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[62], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21;01mbechdelai\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mdata\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mopensubtitles\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m search\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21;01mbechdelai\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mdata\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mopensubtitles\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m get_subtitle_link\n\u001b[1;32m      3\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21;01mbechdelai\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mdata\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mopensubtitles\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m download_subtitle_from_url\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'bechdelai.data.opensubtitles'"
+     ]
+    }
+   ],
+   "source": [
+    "from bechdelai.data.opensubtitles import search\n",
+    "from bechdelai.data.opensubtitles import get_subtitle_link\n",
+    "from bechdelai.data.opensubtitles import download_subtitle_from_url\n",
+    "from bechdelai.data.opensubtitles import get_subtitles_from_movie"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69a5cf59-80f1-449c-93bf-bd6a69d58a45",
+   "metadata": {},
+   "source": [
+    "## Testing scraping TMDB"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab6d71d4-c75a-4cae-99e6-626689c3eb40",
+   "metadata": {},
+   "source": [
+    "<span style=\"color: grey;\"><b>BechdelAI status on scraping TMDB: TO CHECK - MISSING API KEY</b></span>  \n",
+    "=> Module was not integrated. We can use the code because it is clean"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "a95a9d24-f3cd-45df-84a2-84cec5bd3e4d",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "APIKeyNotSetInEnv",
+     "evalue": "You need to set your TMDB API key into a .env file. `TMDB_API_KEY=<API_KEY>` To get a key please check directly on the website https://developers.themoviedb.org/3/getting-started/introduction",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "File \u001b[0;32m/usr/local/lib/python3.9/site-packages/bechdelai/data/tmdb.py:24\u001b[0m\n\u001b[1;32m     23\u001b[0m     load_dotenv()\n\u001b[0;32m---> 24\u001b[0m     API_KEY \u001b[38;5;241m=\u001b[39m \u001b[43menviron\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mTMDB_API_KEY\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\n\u001b[1;32m     25\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m:\n",
+      "File \u001b[0;32m/usr/local/lib/python3.9/os.py:679\u001b[0m, in \u001b[0;36m_Environ.__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m    677\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m:\n\u001b[1;32m    678\u001b[0m     \u001b[38;5;66;03m# raise KeyError with the original key value\u001b[39;00m\n\u001b[0;32m--> 679\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(key) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[1;32m    680\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdecodevalue(value)\n",
+      "\u001b[0;31mKeyError\u001b[0m: 'TMDB_API_KEY'",
+      "\nDuring handling of the above exception, another exception occurred:\n",
+      "\u001b[0;31mAPIKeyNotSetInEnv\u001b[0m                         Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[63], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21;01mbechdelai\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mdata\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mtmdb\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m search_movie_from_query\n",
+      "File \u001b[0;32m/usr/local/lib/python3.9/site-packages/bechdelai/data/tmdb.py:26\u001b[0m\n\u001b[1;32m     24\u001b[0m     API_KEY \u001b[38;5;241m=\u001b[39m environ[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mTMDB_API_KEY\u001b[39m\u001b[38;5;124m\"\u001b[39m]\n\u001b[1;32m     25\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m:\n\u001b[0;32m---> 26\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m APIKeyNotSetInEnv(\n\u001b[1;32m     27\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mYou need to set your TMDB API key into a .env file. `TMDB_API_KEY=<API_KEY>` \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m     28\u001b[0m         \u001b[38;5;241m+\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mTo get a key please check directly on the website https://developers.themoviedb.org/3/getting-started/introduction\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m     29\u001b[0m     )\n\u001b[1;32m     31\u001b[0m \u001b[38;5;66;03m# main urls\u001b[39;00m\n\u001b[1;32m     32\u001b[0m MAIN_URL \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mhttps://www.themoviedb.org\u001b[39m\u001b[38;5;124m\"\u001b[39m\n",
+      "\u001b[0;31mAPIKeyNotSetInEnv\u001b[0m: You need to set your TMDB API key into a .env file. `TMDB_API_KEY=<API_KEY>` To get a key please check directly on the website https://developers.themoviedb.org/3/getting-started/introduction"
+     ]
+    }
+   ],
+   "source": [
+    "from bechdelai.data.tmdb import search_movie_from_query"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2fcfd139-f3d2-4211-88c4-325c9b70d16f",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
+   "source": [
+    "## Testing scraping Wikipedia"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2343db69-ee32-4103-811f-adf367323be4",
+   "metadata": {},
+   "source": [
+    "<span style=\"color: red;\"><b>BechdelAI status on scraping Wikipedia: FAILURE</b></span>  \n",
+    "=> Module was not integrated. We can use the code because it is clean"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "id": "704edfbe-b668-487e-b705-81e5ce44462f",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'bechdelai.data.wikipedia'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[64], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21;01mbechdelai\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mdata\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mwikipedia\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mas\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21;01mwiki\u001b[39;00m\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'bechdelai.data.wikipedia'"
+     ]
+    }
+   ],
+   "source": [
+    "import bechdelai.data.wikipedia as wiki"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38f2300f-6c3f-400c-9e5d-b6450835ab5c",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
+   "source": [
+    "## Testing scraping Scenarioteque"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "204f9868-161e-495b-b4b1-e4d7222f8fd5",
+   "metadata": {},
+   "source": [
+    "<span style=\"color: red;\"><b>BechdelAI status on scraping scenarioteque: FAILURE</b></span>  \n",
+    "=> Module was not integrated. We can use the code because it is clean"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "id": "e1cec318-c998-46ef-9df9-bb2d9e20d648",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'bechdelai.data.scenarioteque'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[65], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21;01mbechdelai\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mdata\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mscenarioteque\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m get_scripts\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'bechdelai.data.scenarioteque'"
+     ]
+    }
+   ],
+   "source": [
+    "from bechdelai.data.scenarioteque import get_scripts"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.21"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
I have worked on trying to understand better the `bechdelai` python library created by Data4Good season 10 (also working for collectif 5050) and also to see if it could be used from the shelf to help us.

My main conclusions are
- The `bechdelai` library was designed to provide easy access to a wide variety of movie related sources with API fetching or websites scrapping. The sources were:
  - allocine with scraping
  - tmdb with API
  - imdb with scraping
  - imsdb with scraping
  - bechdeltest.com with fetching
  - opensubtitles with scraping
  - scenarioteque with scraping
- Actually out of all of these potentially available sources:
  - IMSDB (movie scripts) is the only data source that is accessible and functional
  - IMDB is accessible but raises errors (probably due to imdb changing their html)
  - All the other sources are actually not available: WHY?
- In a summary the library cannot be used straight away, but it has been well coded so a question remained on whether we should just copy-paste the code or try to fix the library to reuse it?
