### PR TITLE
fix (pre-commit.yaml): upgrade deprecated safety

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -16,10 +16,16 @@ jobs:
       run: |
         python -m pip install poetry
         poetry install
-    - name: Install safety
-      run: poetry run pip install safety
-    - name: Run safety check
-      run: poetry run safety check --full-report
+    - name: Install Poetry Export Plugin
+      run: |
+        export PATH="$HOME/.local/bin:$PATH"
+        poetry self add poetry-plugin-export
+    - name: Install pip-audit
+      run: python -m pip install pip-audit
+    - name: Export requirements from poetry
+      run: poetry export -f requirements.txt --without-hashes -o requirements.txt
+    - name: Run pip-audit
+      run: pip-audit -r requirements.txt
     - name: set PY
       run: echo "PY=$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')" >> $GITHUB_ENV
     - uses: actions/cache@v3


### PR DESCRIPTION
- What? CI fails due to this error : `Unhandled exception happened: post_dump() got an unexpected keyword argument 'pass_many'`. We need to upgrade the way we check libraries
- Why? Safety check is deprecated and to use safety scan we need to log in with an api
- How? Use pip audit instead because it is free and requires no login