### PR TITLE
[FEAT] Adding statistics page

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,17 +2,6 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   distDir: "dist",
-  images: {
-    remotePatterns: [
-      {
-        protocol: "https",
-        hostname: "fr.web.img6.acsta.net",
-        port: "",
-        pathname: "/img/29/eb/**",
-        search: "",
-      },
-    ],
-  },
 };
 
 export default nextConfig;

--- a/frontend/src/app/statistics/page.tsx
+++ b/frontend/src/app/statistics/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function StatisticsPage() {
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+  const [iFrameUrl, setIFrameUrl] = useState('');
+
+  useEffect(() => {
+    const url = 'http://localhost:5001/metabase/iframe-url';
+    fetch(url)
+      .then((response) => {
+        if (response.ok) {
+          return response.json();
+        }
+        throw new Error("Fetch error");
+      })
+      .then((value: {iframe_url: string}) => {
+        setIFrameUrl(value.iframe_url);
+        setIsLoading(false);
+      })
+      .catch(() => {
+        setHasError(true);
+        setIsLoading(false);
+      });
+  }, []);
+
+  if (isLoading || !iFrameUrl) {
+    return (
+      <main className="p-40 bg-transparent text-white flex justify-center items-center">
+        <p>Chargement...</p>
+      </main>
+    );
+  }
+
+  if (hasError) {
+    return (
+      <main className="p-40 bg-transparent text-white flex justify-center items-center">
+        <h1 className="text-4xl font-bold">Une erreur est survenue lors de la récupération des statistiques</h1>
+      </main>
+    );
+  }
+
+  return (
+    <main className="flex flex-col items-center justify-center bg-gray-950 text-white">
+      <div className="p-10 pt-40 w-full">
+        <iframe
+          src={iFrameUrl}
+          width="100%"
+          height="1650px"
+          allowFullScreen
+        />
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/statistics/page.tsx
+++ b/frontend/src/app/statistics/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { API_URL } from "@/utils/api-url";
 import { useEffect, useState } from "react";
 
 export default function StatisticsPage() {
@@ -8,7 +9,7 @@ export default function StatisticsPage() {
   const [iFrameUrl, setIFrameUrl] = useState('');
 
   useEffect(() => {
-    const url = 'http://localhost:5001/metabase/iframe-url';
+    const url = `${API_URL}/metabase/iframe-url`;
     fetch(url)
       .then((response) => {
         if (response.ok) {

--- a/frontend/src/components/atoms/Navbar.tsx
+++ b/frontend/src/components/atoms/Navbar.tsx
@@ -113,13 +113,13 @@ const Navbar = ({
         </div>
       ) : (
         <nav
-          className={`text-white fixed w-full z-10 ${
+          className={`text-white absolute w-full z-10 ${
             isOpen ? "flex flex-col h-full bg-zinc-800" : ""
           } md:bg-transparent`}
         >
-          {pathname === "/" && !isOpen && (
+          {["/", "/statistics"].includes(pathname) && !isOpen && (
             <div
-              className="absolute mx-16"
+              className="absolute mx-16 cursor-pointer"
               style={{
                 width: "230px",
                 paddingTop: "20px",
@@ -136,23 +136,23 @@ const Navbar = ({
               {/* Menu desktop */}
               <div className="hidden md:block">
                 <div className="ml-10 flex items-center space-x-4">
-                  <Link href="/" className="px-3 py-2 rounded-md">
+                  <Link href="/" className="px-3 py-2 rounded-md cursor-pointer">
                     Accueil
                   </Link>
-                  <Link href="/statistics" className="px-3 py-2 rounded-md">
+                  <Link href="/statistics" className="px-3 py-2 rounded-md cursor-pointer">
                     Statistiques
                   </Link>
-                  <Link href="/about" className="px-3 py-2 rounded-md">
+                  <Link href="/about" className="px-3 py-2 rounded-md cursor-pointer">
                     À propos
                   </Link>
                   <button
-                    className="px-3 py-2 rounded-md"
+                    className="px-3 py-2 rounded-md cursor-pointer"
                     onClick={() => setIsSearching(!isSearching)}
                   >
                     <Image src="/search.svg" alt="Rechercher" height={36} width={36} />
                   </button>
                   <Link href="/dashboard" className="px-3 py-2 rounded-md">
-                    <Button>Donnez nous votre avis 💬</Button>
+                    <Button className="cursor-pointer">Donnez nous votre avis 💬</Button>
                   </Link>
                 </div>
               </div>
@@ -203,21 +203,21 @@ const Navbar = ({
               <div className="px-2 pt-2 pb-3 space-y-1 h-full flex flex-col justify-center items-center">
                 <Link
                   href="/"
-                  className="block hover:bg-gray-700 px-3 py-2 rounded-md"
+                  className="block hover:bg-gray-700 px-3 py-2 rounded-md cursor-pointer"
                   onClick={toggleMenu}
                 >
                   Accueil
                 </Link>
                 <Link
                   href="/statistics"
-                  className="block hover:bg-gray-700 px-3 py-2 rounded-md"
+                  className="block hover:bg-gray-700 px-3 py-2 rounded-md cursor-pointer"
                   onClick={toggleMenu}
                 >
                   Statistiques
                 </Link>
                 <Link
                   href="/about"
-                  className="block hover:bg-gray-700 px-3 py-2 rounded-md"
+                  className="block hover:bg-gray-700 px-3 py-2 rounded-md cursor-pointer"
                   onClick={toggleMenu}
                 >
                   À propos
@@ -229,7 +229,7 @@ const Navbar = ({
                   className="block px-3 py-2 rounded-md"
                   onClick={toggleMenu}
                 >
-                  <Button className="w-full bg-white text-black hover:text-white">
+                  <Button className="w-full bg-white text-black hover:text-white cursor-pointer">
                     Donnez nous votre avis 💬
                   </Button>
                 </Link>

--- a/frontend/src/components/atoms/Navbar.tsx
+++ b/frontend/src/components/atoms/Navbar.tsx
@@ -7,6 +7,7 @@ import { Input } from "../ui/input";
 import { usePathname } from "next/navigation";
 import { SearchFilmResultDto } from "@/dto/film/search-film-result.dto";
 import Image from "next/image";
+import { API_URL } from "@/utils/api-url";
 
 const Navbar = ({
   children,
@@ -28,7 +29,7 @@ const Navbar = ({
     setSearchQuery(query);
     if (query) {
       try {
-        const url = `http://localhost:5001/search?q=${query}`;
+        const url = `${API_URL}/search?q=${query}`;
         const response = await fetch(url); // Default mode (CORS enabled on backend)
 
         if (!response.ok) {


### PR DESCRIPTION
This PR adds a new "Statistics" page that displays various charts using Metabase embeds.
The integration is handled via iframe elements, where the source URLs are dynamically retrieved from the backend.

Key changes:
- Created a new page: /statistics
- Added logic to fetch signed Metabase iframe URLs from the backend via the endpoint /metabase/iframe-url
- Embedded the returned URLs into iframe components for chart rendering