### PR TITLE
hotfix(certbot) : surface silent renewal failures in logs

### DIFF
--- a/certbot/entrypoint.sh
+++ b/certbot/entrypoint.sh
@@ -1,11 +1,21 @@
 #!/bin/sh
-set -euo pipefail
+set -u
 
 trap 'exit 0' TERM INT
 
-# Renew certificates and signal nginx for immediate reload via shared volume.
+log() { echo "[$(date -Iseconds)] certbot-loop: $*"; }
+
+if [ ! -d /etc/letsencrypt/live ] || [ -z "$(ls -A /etc/letsencrypt/live 2>/dev/null)" ]; then
+  log "WARNING: no certificate found in /etc/letsencrypt/live. 'certbot renew' will not create one — run 'certbot certonly' first to issue the initial cert."
+fi
+
 while :; do
-  certbot renew --quiet \
-    --deploy-hook 'date +%s > /etc/letsencrypt/.reload'
-  sleep 12h
+  log "running certbot renew"
+  if certbot renew --deploy-hook 'date +%s > /etc/letsencrypt/.reload'; then
+    log "renew OK"
+  else
+    rc=$?
+    log "renew FAILED (exit $rc) — retry in 12h"
+  fi
+  sleep 43200
 done

--- a/poetry.lock
+++ b/poetry.lock
@@ -2532,15 +2532,18 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.1"
 description = "JSON Web Token implementation in Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469"},
-    {file = "pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623"},
+    {file = "pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c"},
+    {file = "pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b"},
 ]
+
+[package.dependencies]
+typing_extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 crypto = ["cryptography (>=3.4.0)"]
@@ -2608,14 +2611,14 @@ six = ">=1.5"
 
 [[package]]
 name = "python-dotenv"
-version = "1.2.1"
+version = "1.2.2"
 description = "Read key-value pairs from a .env file and set them as environment variables"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61"},
-    {file = "python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6"},
+    {file = "python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a"},
+    {file = "python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3"},
 ]
 
 [package.extras]
@@ -3783,4 +3786,4 @@ test = ["pytest", "websockets"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "c59c5f64ad1f3ea594f8c24da1d9c1d300d6ea8ecefe345f7ea6ce10b13a8893"
+content-hash = "c81384982a640d286f31c0da63d2b6081eb19437dfc1f041004b30cdcb672ec1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,14 +18,14 @@ uvicorn = "^0.34.0"
 sqlalchemy = "^2.0.38"
 psycopg = {extras = ["binary"], version = "^3.2.9"}
 alembic = "^1.15.1"
-python-dotenv = "^1.0.1"
+python-dotenv = "^1.2.2"
 beautifulsoup4 = "^4.13.3"
 openpyxl = "^3.1.5"
 tqdm = "^4.67.1"
 h11 = "^0.16.0"
 gender-guesser = "^0.4.0"
 dateparser = "^1.2.1"
-pyjwt = "^2.10.1"
+pyjwt = "^2.12.0"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^2.20.0"


### PR DESCRIPTION
The certbot renewal loop was failing silently in production, leaving the Let's Encrypt certificate to expire without any visible error. Three mechanisms were swallowing the signal:
- set -e killed the whole loop on any non-zero exit from certbot renew (including transient network/rate-limit errors), so a single bad run stopped all future attempts.
- --quiet suppressed certbot output, making it impossible to diagnose what actually went wrong.
- certbot renew is a no-op when no certificate exists yet, so a missing /etc/letsencrypt/live volume produced zero output.

This change removes set -e, drops --quiet, adds a timestamped log line per iteration, logs the exit code on failure so the loop keeps running, and warns explicitly at startup if no certificate is present. sleep 12h is replaced by sleep 43200 to avoid relying on BusyBox sleep suffix support.